### PR TITLE
Using GitRevisionPlugin for filename hashing

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -34,6 +34,7 @@ const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
 // @remove-on-eject-begin
 const getCacheIdentifier = require('react-dev-utils/getCacheIdentifier');
 // @remove-on-eject-end
+const GitRevisionPlugin = require('git-revision-webpack-plugin')
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
 const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
@@ -161,11 +162,11 @@ module.exports = function(webpackEnv) {
       // There will be one main bundle, and one file per asynchronous chunk.
       // In development, it does not produce real files.
       filename: isEnvProduction
-        ? 'static/js/[name].[contentHash].js'
+        ? 'static/js/[name].[git-revision-hash].js'
         : isEnvDevelopment && 'static/js/bundle.js',
       // There are also additional JS chunk files if you use code splitting.
       chunkFilename: isEnvProduction
-        ? 'static/js/[name].[contentHash].chunk.js'
+        ? 'static/js/[name].[git-revision-hash].chunk.js'
         : isEnvDevelopment && 'static/js/[name].chunk.js',
       // We inferred the "public path" (such as / or /my-project) from homepage.
       // We use "/" in development.
@@ -519,6 +520,9 @@ module.exports = function(webpackEnv) {
       ],
     },
     plugins: [
+      new GitRevisionPlugin({
+        commithashCommand: 'rev-parse --short --max-count=1 HEAD',
+      }),
       // Generates an `index.html` file with the <script> injected.
       new HtmlWebpackPlugin(
         Object.assign(

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshnabbott/react-scripts",
-  "version": "2.1.3",
+  "version": "2.1.32",
   "description": "Configuration and scripts for Create React App.",
   "repository": "joshnabbott/create-react-app",
   "license": "MIT",
@@ -73,6 +73,7 @@
     "workbox-webpack-plugin": "3.6.3"
   },
   "devDependencies": {
+    "git-revision-webpack-plugin":  "file:/Users/joshuaabbott/code/git-revision-webpack-plugin",
     "react": "^16.3.2",
     "react-dom": "^16.3.2"
   },


### PR DESCRIPTION
Using GitRevisionPlugin for filename hashing to solve the issue of inconsistent file names on multiple app servers