### PR TITLE
chore: bump version to 3.1.22

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshnabbott/react-scripts",
-  "version": "3.1.2",
+  "version": "3.1.22",
   "description": "Configuration and scripts for Create React App.",
   "repository": "joshnabbott/create-react-app",
   "license": "MIT",


### PR DESCRIPTION
No code change. Just a version bump to indicate it's ours `react-scripts 3.1.2` is `3.1.22` here